### PR TITLE
Lock Emscripten to 1.39.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@v1
 
       - uses: mymindstorm/setup-emsdk@v6
+        with:
+          version: 1.39.20
 
       - name: install
         run: yarn install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/checkout@v1
 
       - uses: mymindstorm/setup-emsdk@v6
+        with:
+          version: 1.39.20
 
       - name: install
         run: yarn install


### PR DESCRIPTION
There [seems to be an issue](https://github.com/emscripten-core/emscripten/issues/12238) with the latest (unreleased) LLVM version (12.0.0) that Emscripten is using since 1.40.0, resulting in a compiler crash when building the code. Until resolved, we should to lock the Emscripten version used to the most recent version able to build the project.